### PR TITLE
Update cron schedule in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   schedule:
-    - cron: "30 16 * * *"
+    - cron: "0 * * * *"
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */6 * * *"
 
 jobs:
   check:


### PR DESCRIPTION
Update the cron schedule in the ci.yml file to run the job every hour instead of at 4:30 PM. This change ensures that the job runs more frequently and keeps the CI pipeline up to date.